### PR TITLE
Replace `patch-desktop-filename` with `patch-electron-desktop-filename`

### DIFF
--- a/us.materialio.Materialious.yml
+++ b/us.materialio.Materialious.yml
@@ -57,4 +57,4 @@ modules:
       - install -Dm644 us.materialio.Materialious.svg /app/share/icons/hicolor/scalable/apps/us.materialio.Materialious.svg
       - install -Dm644 us.materialio.Materialious.desktop -t /app/share/applications/
       - install -Dm644 us.materialio.Materialious.metainfo.xml -t /app/share/metainfo/
-      - patch-desktop-filename "${FLATPAK_DEST}"/materialious/resources/app.asar
+      - patch-electron-desktop-filename "${FLATPAK_DEST}"/materialious/resources/app.asar


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.